### PR TITLE
New redirects always save with highest ID site

### DIFF
--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -351,6 +351,15 @@ class SettingsController extends Controller
 
             return null;
         } else {
+          // remove form other sites
+          Craft::$app->getDb()->createCommand()
+            ->delete('{{%elements_sites}}', [
+              'AND',
+              ['elementId' => $redirect->id],
+              ['!=', 'siteId', $siteId]
+            ])
+            ->execute();
+
             if ($request->getAcceptsJson()) {
                 return $this->asJson([
                     'success' => true,

--- a/src/elements/Redirect.php
+++ b/src/elements/Redirect.php
@@ -346,14 +346,6 @@ class Redirect extends Element
 
         $record->save(false);
 
-        // remove form other sites
-        Craft::$app->getDb()->createCommand()
-            ->delete('{{%elements_sites}}', [
-                'AND',
-                ['elementId' => $record->id],
-                ['!=', 'siteId', $this->siteId]
-            ])
-            ->execute();
         parent::afterSave($isNew);
     }
 


### PR DESCRIPTION
Hi, love the plugin! However, I recently upgraded to Craft 3.2.7 and have found that redirects are no longer saving on the correct sites.

I did some sleuthing and found that though the `$propagate` parameter [is set to false when saving the redirect](https://github.com/Dolphiq/craft3-plugin-redirect/blob/06274bac37e7851ecb4934f1bdc00e2b61899c68/src/controllers/SettingsController.php#L337), this only stops it from being saved to all sites if the record exists ([see Arguments here](https://docs.craftcms.com/api/v3/craft-services-elements.html#method-saveelement)).

To get around this, in the `afterSave` callback, all element records created for sites that aren't the relevant one are deleted. Unfortunately, this is run every time a record is saved (and it always gets saved for all sites when a new record is created), meaning that the only lingering redirect record is one on the highest site ID.

This PR shifts the record deletion to occur in the Controller's action for saving instead of in a post-save callback, so it's only executed for the record on the relevant site.