### PR TITLE
Escape column name "hitAt".

### DIFF
--- a/src/elements/db/RedirectQuery.php
+++ b/src/elements/db/RedirectQuery.php
@@ -144,7 +144,8 @@ class RedirectQuery extends ElementQuery
             $inactiveDate = new \DateTime();
             $inactiveDate->modify("-60 days");
 
-            $this->subQuery->andWhere('(dolphiq_redirects.hitAt < :calculatedDate AND dolphiq_redirects.hitAt IS NOT NULL)', [':calculatedDate' => $inactiveDate->format("Y-m-d H:m:s")]);
+            $this->subQuery->andWhere(Db::parseParam('dolphiq_redirects.hitAt', $inactiveDate->format("Y-m-d H:m:s"), '<'));
+            $this->subQuery->andWhere(Db::parseParam('dolphiq_redirects.hitAt', ':notempty:'));
         }
 
         // $this->subQuery->andWhere(Db::parseParam('elements_sites.siteId', null));


### PR DESCRIPTION
PostgreSQL converts unescaped column names to lowercase. Causing the
query to fail for being unable to find column "hitat".

Error thrown:

```
Next yii\db\Exception: SQLSTATE[42703]: Undefined column: 7 ERROR:  column dolphiq_redirects.hitat does not exist                                                                                                                              
LINE 6: WHERE ((dolphiq_redirects.hitAt < $1 AND dolphiq_redirects.h...                                                                                                                                                                        
                ^                                                                                                                                                                                                                              
HINT:  Perhaps you meant to reference the column "dolphiq_redirects.hitAt".                                                                                                                                                                    
The SQL being executed was: SELECT COUNT(*)                                                                                                                                                                                                    
FROM (SELECT "elements"."id" AS "elementsId", "elements_sites"."id" AS "elementsSitesId"                                                                                                                                                       
FROM "elements" "elements"                                                                                                                                                                                                                     
INNER JOIN "dolphiq_redirects" "dolphiq_redirects" ON "dolphiq_redirects"."id" = "elements"."id"                                                                                                                                               
INNER JOIN "elements_sites" "elements_sites" ON "elements_sites"."elementId" = "elements"."id"                                                                                                                                                 
WHERE ((dolphiq_redirects.hitAt < '2019-09-12 09:09:56' AND dolphiq_redirects.hitAt IS NOT NULL)) AND ("elements_sites"."siteId"='1') AND ("elements"."archived"=FALSE) AND ("elements"."dateDeleted" IS NULL) AND ("elements"."draftId" IS NULL) AND ("elements"."revisionId" IS NULL)) "subquery"                                                                                                                                                                                           
INNER JOIN "dolphiq_redirects" "dolphiq_redirects" ON "dolphiq_redirects"."id" = "subquery"."elementsId"                                                                                                                                       
INNER JOIN "elements" "elements" ON "elements"."id" = "subquery"."elementsId"                                                                                                                                                                  
INNER JOIN "elements_sites" "elements_sites" ON "elements_sites"."id" = "subquery"."elementsSitesId" in /code/vendor/yiisoft/yii2/db/Schema.php:664
```