### PR TITLE
Avoid url encoded placeholders in destination URL

### DIFF
--- a/src/controllers/RedirectController.php
+++ b/src/controllers/RedirectController.php
@@ -65,7 +65,7 @@ class RedirectController extends Controller
             foreach ($matches[1] as $name) {
                 if (isset($sourceParameters[$name])) {
                     $destinationUrl = str_ireplace("<$name>", $sourceParameters[$name], $destinationUrl);
-                } elseif (isset($_GET[$name])) {
+                } else {
                     $destinationUrl = str_ireplace("<$name>", $_GET[$name], $destinationUrl);
                 }
             }


### PR DESCRIPTION
Avoid ending up with url encoded placeholders in the destination URL whenever we couldn't find the get parameter in the incoming request.

This kind of redirect:
```
/some-source-url --> /some-destination-url?foo=<foo>
```
would give us
```
/some-source-url?foo=bar --> /some-destimation-url?foo=bar
```
which is fine.

But this shouldn't give us
```
/some-source-url --> /some-destimation-url?foo=%3Cfoo%3E
```

I'd rather simply have `/some-destimation-url?foo=` instead.