### PR TITLE
Check if querystring isset before adding questionmark to destinationUrl

### DIFF
--- a/src/controllers/RedirectController.php
+++ b/src/controllers/RedirectController.php
@@ -87,7 +87,7 @@ class RedirectController extends Controller
             $destinationUrl = UrlHelper::baseUrl() . ltrim($destinationUrl, '/');
         }
 
-        if(isset($queryString)) {
+        if($queryString) {
             $destinationUrl .= "?" . $queryString;
         }
 

--- a/src/controllers/RedirectController.php
+++ b/src/controllers/RedirectController.php
@@ -54,6 +54,7 @@ class RedirectController extends Controller
         }
 
         $routeParameters = Craft::$app->getUrlManager()->getRouteParams();
+        $queryString = $this->request->getQueryStringWithoutPath();
         $sourceUrl = $routeParameters['sourceUrl'];
         $destinationUrl = $routeParameters['destinationUrl'];
         $statusCode = $routeParameters['statusCode'];
@@ -86,7 +87,9 @@ class RedirectController extends Controller
             $destinationUrl = UrlHelper::baseUrl() . ltrim($destinationUrl, '/');
         }
 
-        $destinationUrl .= "?" . $this->request->getQueryStringWithoutPath();
+        if(isset($queryString)) {
+            $destinationUrl .= "?" . $queryString;
+        }
 
         // register the hit to the database
         if ($redirectId != null && $statusCode != 404) {


### PR DESCRIPTION
Google complains about an alternate page with proper canonical tag because for every redirect there is a question mark added to the destination URL. 